### PR TITLE
Update .travis.yml php version in coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
   - php: 5.4
     env: PHPCS=1 DEFAULT=0
 
-  - php: 5.4
+  - php: 5.5
     env: COVERALLS=1 DEFAULT=0 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
 install:


### PR DESCRIPTION
TravisCI is failing:

>  satooshi/php-coveralls dev-master requires php >=5.5 -> your PHP version (5.4.37)
