### PR TITLE
Add localization for templates and vars, with CakePHP i18n table.

### DIFF
--- a/src/Controller/Component/NotifierComponent.php
+++ b/src/Controller/Component/NotifierComponent.php
@@ -109,6 +109,32 @@ class NotifierComponent extends Component
 
         return $query->toArray();
     }
+    
+    /**
+     * getI18nNotifications
+     *
+     * Returns a list of translated notifications.
+     *
+     * @param int|null $userId Id of the user.
+     * @param bool|null $state The state of notifications: `true` for unread, `false` for read, `null` for all.
+     * @return array
+     */
+    public function getI18nNotifications($userId = null, $state = null)
+    {
+        if (!$userId) {
+            $userId = $this->Controller->Auth->user('id');
+        }
+
+        $model = TableRegistry::get('Notifier.Notifications');
+
+        $query = $model->find('translations')->where(['Notifications.user_id' => $userId])->order(['created' => 'desc']);
+
+        if (!is_null($state)) {
+            $query->where(['Notifications.state' => $state]);
+        }
+
+        return $query->toArray();
+    }
 
     /**
      * countNotifications

--- a/src/Model/Entity/Notification.php
+++ b/src/Model/Entity/Notification.php
@@ -15,9 +15,9 @@
 namespace Notifier\Model\Entity;
 
 use Cake\Core\Configure;
+use Cake\ORM\Behavior\Translate\TranslateTrait;
 use Cake\ORM\Entity;
 use Cake\Utility\Text;
-use Cake\ORM\Behavior\Translate\TranslateTrait;
 
 /**
  * Notification Entity.
@@ -155,14 +155,14 @@ class Notification extends Entity
     
     /**
      * getI18n
-     * 
+     *
      * Get localized property
-     * 
+     *
      * @param string $property : `title` or `body`
-     * @param string|null $lang
+     * @param string|null $lang : language code
      * @return type
      */
-    public function getI18n($property, $lang = null) 
+    public function getI18n($property, $lang = null)
     {
         $templates = Configure::read('Notifier.templates.i18n');
 

--- a/src/Model/Entity/Notification.php
+++ b/src/Model/Entity/Notification.php
@@ -17,12 +17,15 @@ namespace Notifier\Model\Entity;
 use Cake\Core\Configure;
 use Cake\ORM\Entity;
 use Cake\Utility\Text;
+use Cake\ORM\Behavior\Translate\TranslateTrait;
 
 /**
  * Notification Entity.
  */
 class Notification extends Entity
 {
+
+    use TranslateTrait;
 
     /**
      * Fields that can be mass assigned using newEntity() or patchEntity().
@@ -148,6 +151,36 @@ class Notification extends Entity
             return true;
         }
         return false;
+    }
+    
+    /**
+     * getI18n
+     * 
+     * Get localized property
+     * 
+     * @param string $property : `title` or `body`
+     * @param string|null $lang
+     * @return type
+     */
+    public function getI18n($property, $lang = null) 
+    {
+        $templates = Configure::read('Notifier.templates.i18n');
+
+        if (array_key_exists($this->_properties['template'], $templates) && array_key_exists($lang, $templates[$this->_properties['template']])) {
+            $template = $templates[$this->_properties['template']][$lang];
+
+            if (isset($this->_translations[$lang]['vars'])) {
+                $vars = json_decode($this->_translations[$lang]['vars'], true);
+            } else {
+                $vars = json_decode($this->_properties['vars'], true);
+            }
+
+            if (isset($template[$property])) {
+                return Text::insert($template[$property], $vars);
+            }
+        }
+
+        return '';
     }
 
     /**

--- a/src/Model/Entity/Notification.php
+++ b/src/Model/Entity/Notification.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CakeManager (http://cakemanager.org)
  * Copyright (c) http://cakemanager.org
@@ -12,6 +13,7 @@
  * @since         1.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Notifier\Model\Entity;
 
 use Cake\Core\Configure;
@@ -152,7 +154,7 @@ class Notification extends Entity
         }
         return false;
     }
-    
+
     /**
      * getI18n
      *

--- a/src/Model/Table/NotificationsTable.php
+++ b/src/Model/Table/NotificationsTable.php
@@ -43,6 +43,10 @@ class NotificationsTable extends Table
         $this->displayField('title');
         $this->primaryKey('id');
         $this->addBehavior('Timestamp');
+        $this->addBehavior('Translate', [
+            'fields' => ['vars'],
+            'allowEmptyTranslations' => false
+        ]);
     }
 
     /**

--- a/src/Utility/NotificationManager.php
+++ b/src/Utility/NotificationManager.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CakeManager (http://cakemanager.org)
  * Copyright (c) http://cakemanager.org
@@ -12,6 +13,7 @@
  * @since         1.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Notifier\Utility;
 
 use Cake\Core\Configure;
@@ -106,7 +108,6 @@ class NotificationManager
 
         return $data['tracking_id'];
     }
-    
 
     /**
      * notifyI18n
@@ -153,25 +154,25 @@ class NotificationManager
 
         $data = array_merge($_data, $data);
 
-        foreach ((array) $data['recipientLists'] as $recipientList) {
-            $list = (array) $this->getRecipientList($recipientList);
+        foreach ((array)$data['recipientLists'] as $recipientList) {
+            $list = (array)$this->getRecipientList($recipientList);
             $data['users'] = array_merge($data['users'], $list);
         }
 
-        foreach ((array) $data['users'] as $user) {
+        foreach ((array)$data['users'] as $user) {
             $entity = $model->newEntity();
-            
+
             $entity->set('template', $data['template']);
             $entity->set('tracking_id', $data['tracking_id']);
-                
+
             $entity->set('vars', current($data['vars']));
             foreach ($data['vars'] as $lang => $vars) {
                 $entity->translation($lang)->set(['vars' => $vars], ['guard' => false]);
             }
-            
+
             $entity->set('state', 1);
             $entity->set('user_id', $user);
-            
+
             $model->save($entity);
         }
 
@@ -361,4 +362,5 @@ class NotificationManager
         }
         return $trackingId;
     }
+
 }

--- a/src/Utility/NotificationManager.php
+++ b/src/Utility/NotificationManager.php
@@ -362,5 +362,4 @@ class NotificationManager
         }
         return $trackingId;
     }
-
 }

--- a/src/Utility/NotificationManager.php
+++ b/src/Utility/NotificationManager.php
@@ -106,6 +106,77 @@ class NotificationManager
 
         return $data['tracking_id'];
     }
+    
+
+    /**
+     * notifyI18n
+     *
+     * Sends notifications to specific users.
+     * The first parameter `$data` is an array with multiple options.
+     *
+     * ### Options
+     * - `users` - An array or int with id's of users who will receive a notification.
+     * - `roles` - An array or int with id's of roles which all users ill receive a notification.
+     * - `template` - The template wich will be used.
+     * - `vars` - The localized variables used in the template.
+     *
+     * ### Example
+     * ```
+     *  NotificationManager::instance()->notify([
+     *      'users' => 1,
+     *      'template' => 'newOrder',
+     *      'vars' => [
+     *          'en' => [
+     *              'receiver' => $receiver->name
+     *              'link' => '/en/order/],
+     *          'fr' => [
+     *              'receiver' => $receiver->name
+     *              'link' => '/fr/order/],
+     *      ],
+     *  ]);
+     * ```
+     *
+     * @param array $data Data with options.
+     * @return string The tracking_id to follow the notification.
+     */
+    public function notifyI18n($data)
+    {
+        $model = TableRegistry::get('Notifier.Notifications');
+
+        $_data = [
+            'users' => [],
+            'recipientLists' => [],
+            'template' => 'default',
+            'vars' => [],
+            'tracking_id' => $this->getTrackingId()
+        ];
+
+        $data = array_merge($_data, $data);
+
+        foreach ((array) $data['recipientLists'] as $recipientList) {
+            $list = (array) $this->getRecipientList($recipientList);
+            $data['users'] = array_merge($data['users'], $list);
+        }
+
+        foreach ((array) $data['users'] as $user) {
+            $entity = $model->newEntity();
+            
+            $entity->set('template', $data['template']);
+            $entity->set('tracking_id', $data['tracking_id']);
+                
+            $entity->set('vars', current($data['vars']));
+            foreach ($data['vars'] as $lang => $vars) {
+                $entity->translation($lang)->set(['vars' => $vars], ['guard' => false]);
+            }
+            
+            $entity->set('state', 1);
+            $entity->set('user_id', $user);
+            
+            $model->save($entity);
+        }
+
+        return $data['tracking_id'];
+    }
 
     /**
      * addRecipientList
@@ -183,6 +254,42 @@ class NotificationManager
     }
 
     /**
+     * addI18nTemplate
+     *
+     * Adds localized template.
+     *
+     * ### Example
+     *
+     * $this->Notifier->addTemplate('newUser', [
+     *  'en' => [
+     *    'title' => 'New User: :name',
+     *    'body' => 'The user :email has been registered'],
+     *  'fr' => [
+     *    'title' => 'Nouvel utilisateur : :name',
+     *    'body' => 'L\'utilisateur :email vient de s\'inscrire'],
+     * ]);
+     *
+     * This code contains the variables `title` and `body`.
+     *
+     * @param string $name Unique name.
+     * @param array $options Options.
+     * @return void
+     */
+    public function addI18nTemplate($name, $options = [])
+    {
+        $_options = [
+            'en' => [
+                'title' => 'Notification',
+                'body' => '',
+            ]
+        ];
+
+        $options = array_merge($_options, $options);
+
+        Configure::write('Notifier.templates.i18n.' . $name, $options);
+    }
+
+    /**
      * getTemplate
      *
      * Returns the requested template.
@@ -195,6 +302,34 @@ class NotificationManager
     public function getTemplate($name, $type = null)
     {
         $templates = Configure::read('Notifier.templates');
+
+        if (array_key_exists($name, $templates)) {
+            if ($type == 'title') {
+                return $templates[$name]['title'];
+            }
+            if ($type == 'body') {
+                return $templates[$name]['body'];
+            }
+            return $templates[$name];
+        }
+
+        return false;
+    }
+
+    /**
+     * getI18nTemplate
+     *
+     * Returns the requested localized template.
+     * If the template or type does not exists, `false` will be returned.
+     *
+     * @param string $lang Language code.
+     * @param string $name Name of the template.
+     * @param string|null $type The type like `title` or `body`. Leave empty to get the whole template.
+     * @return array|string|bool
+     */
+    public function getI18nTemplate($lang, $name, $type = null)
+    {
+        $templates = Configure::read('Notifier.templates.i18n');
 
         if (array_key_exists($name, $templates)) {
             if ($type == 'title') {

--- a/tests/TestCase/Controller/Component/NotifierComponentTest.php
+++ b/tests/TestCase/Controller/Component/NotifierComponentTest.php
@@ -29,7 +29,8 @@ class NotifierComponentTest extends TestCase
 {
 
     public $fixtures = [
-        'plugin.notifier.notifications'
+        'plugin.notifier.notifications',
+        'core.translates'
     ];
 
     public function setUp()
@@ -106,6 +107,29 @@ class NotifierComponentTest extends TestCase
         $this->assertEquals(2, count($this->Notifier->getNotifications(2)));
         $this->assertEquals(0, count($this->Notifier->getNotifications(2, true)));
         $this->assertEquals(2, count($this->Notifier->getNotifications(2, false)));
+    }
+
+    public function testGetI18nNotifications()
+    {
+        $this->Manager->notify(['users' => [1, 1, 1, 2, 2]]);
+
+        $this->assertEquals(3, count($this->Notifier->getI18nNotifications(1)));
+        $this->assertEquals(3, count($this->Notifier->getI18nNotifications(1, true)));
+        $this->assertEquals(0, count($this->Notifier->getI18nNotifications(1, false)));
+        $this->assertEquals(2, count($this->Notifier->getI18nNotifications(2)));
+        $this->assertEquals(2, count($this->Notifier->getI18nNotifications(2, true)));
+        $this->assertEquals(0, count($this->Notifier->getI18nNotifications(2, false)));
+
+        $this->Notifier->markAsRead(2, 1);
+        $this->Notifier->markAsRead(5, 2);
+        $this->Notifier->markAsRead(6, 2);
+
+        $this->assertEquals(3, count($this->Notifier->getI18nNotifications(1)));
+        $this->assertEquals(2, count($this->Notifier->getI18nNotifications(1, true)));
+        $this->assertEquals(1, count($this->Notifier->getI18nNotifications(1, false)));
+        $this->assertEquals(2, count($this->Notifier->getI18nNotifications(2)));
+        $this->assertEquals(0, count($this->Notifier->getI18nNotifications(2, true)));
+        $this->assertEquals(2, count($this->Notifier->getI18nNotifications(2, false)));
     }
 
     public function testMarkAsReadWithAuth()

--- a/tests/TestCase/Model/Table/NotificationsTableTest.php
+++ b/tests/TestCase/Model/Table/NotificationsTableTest.php
@@ -112,5 +112,4 @@ class NotificationsTableTest extends TestCase
         $this->assertEquals('Nouvelle commande', $entity->getI18n('title', 'fr'));
         $this->assertEquals('Bob a acheté une voiture', $entity->getI18n('body', 'fr'));
     }
-
 }

--- a/tests/TestCase/Model/Table/NotificationsTableTest.php
+++ b/tests/TestCase/Model/Table/NotificationsTableTest.php
@@ -18,6 +18,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Notifier\Model\Table\NotificationsTable;
 use Notifier\Utility\NotificationManager;
+use Cake\I18n\I18n;
 
 /**
  * Notifier\Model\Table\NotificationsTable Test Case
@@ -27,6 +28,7 @@ class NotificationsTableTest extends TestCase
     
     public $fixtures = [
         'plugin.notifier.notifications',
+        'core.translates'
     ];
 
     public function setUp()
@@ -64,5 +66,49 @@ class NotificationsTableTest extends TestCase
         $this->assertEquals('newNotification', $entity->template);
         $this->assertEquals('New Notification', $entity->title);
         $this->assertEquals('Bob has sent Leonardo a notification about Programming Stuff', $entity->body);
+    }
+    
+    public function testI18nEntity()
+    {
+        NotificationManager::instance()->addI18nTemplate('newOrder', [
+            'en' => [
+                'title' => 'New order',
+                'body' => ':username bought :product'
+            ],
+            'fr' => [
+                'title' => 'Nouvelle commande',
+                'body' => ':username a acheté :product'
+            ]
+        ]);
+
+        $notify = NotificationManager::instance()->notifyI18n([
+            'users' => 1,
+            'template' => 'newOrder',
+            'vars' => [
+                'en' => [
+                    'username' => 'Bob',
+                    'product' => 'a car'
+                ],
+                'fr' => [
+                    'username' => 'Bob',
+                    'product' => 'une voiture'
+                ]
+            ]
+        ]);
+        
+        I18n::locale('en');
+        $entity = $this->Notifications->get(2);
+        
+        $this->assertEquals('newOrder', $entity->template);
+        $this->assertEquals('New order', $entity->getI18n('title', 'en'));
+        $this->assertEquals('Bob bought a car', $entity->getI18n('body', 'en'));
+        
+        I18n::locale('fr');
+        $entity = $this->Notifications->get(2);
+        
+        $this->assertEquals('newOrder', $entity->template);
+        $this->assertEquals('Nouvelle commande', $entity->getI18n('title', 'fr'));
+        $this->assertEquals('Bob a acheté une voiture', $entity->getI18n('body', 'fr'));
+        
     }
 }

--- a/tests/TestCase/Model/Table/NotificationsTableTest.php
+++ b/tests/TestCase/Model/Table/NotificationsTableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CakeManager (http://cakemanager.org)
  * Copyright (c) http://cakemanager.org
@@ -12,20 +13,21 @@
  * @since         1.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Notifier\Test\TestCase\Model\Table;
 
+use Cake\I18n\I18n;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Notifier\Model\Table\NotificationsTable;
 use Notifier\Utility\NotificationManager;
-use Cake\I18n\I18n;
 
 /**
  * Notifier\Model\Table\NotificationsTable Test Case
  */
 class NotificationsTableTest extends TestCase
 {
-    
+
     public $fixtures = [
         'plugin.notifier.notifications',
         'core.translates'
@@ -67,7 +69,7 @@ class NotificationsTableTest extends TestCase
         $this->assertEquals('New Notification', $entity->title);
         $this->assertEquals('Bob has sent Leonardo a notification about Programming Stuff', $entity->body);
     }
-    
+
     public function testI18nEntity()
     {
         NotificationManager::instance()->addI18nTemplate('newOrder', [
@@ -95,20 +97,20 @@ class NotificationsTableTest extends TestCase
                 ]
             ]
         ]);
-        
+
         I18n::locale('en');
         $entity = $this->Notifications->get(2);
-        
+
         $this->assertEquals('newOrder', $entity->template);
         $this->assertEquals('New order', $entity->getI18n('title', 'en'));
         $this->assertEquals('Bob bought a car', $entity->getI18n('body', 'en'));
-        
+
         I18n::locale('fr');
         $entity = $this->Notifications->get(2);
-        
+
         $this->assertEquals('newOrder', $entity->template);
         $this->assertEquals('Nouvelle commande', $entity->getI18n('title', 'fr'));
         $this->assertEquals('Bob a acheté une voiture', $entity->getI18n('body', 'fr'));
-        
     }
+
 }

--- a/tests/TestCase/Utility/NotificationManagerTest.php
+++ b/tests/TestCase/Utility/NotificationManagerTest.php
@@ -23,7 +23,8 @@ class NotificationManagerTest extends TestCase
 {
 
     public $fixtures = [
-        'plugin.notifier.notifications'
+        'plugin.notifier.notifications',
+        'core.translates'
     ];
 
     public function setUp()


### PR DESCRIPTION
Notifier now accepts translated templates and vars. 

Translated templates can be managed with `addI18nTemplate()`and `getI18nTemplate()`. 

Translated vars are stored into i18n table : 
http://book.cakephp.org/3.0/en/orm/behaviors/translate.html#initializing-the-i18n-database-table
Notification table did not change. 

Notifications are saved with `notifyI18n()`. 
Title and body of translated notification can be retrieved with `$entity->getI18n('title', 'en')`or `$entity->getI18n('body', 'fr')`.
