### PR TITLE
CakePHP update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "type": "cakephp-plugin",
     "require": {
         "php": ">=5.4.16",
-        "cakephp/cakephp": "3.3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "*",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "require": {
         "php": ">=5.4.16",
-        "cakephp/cakephp": "3.2.*"
+        "cakephp/cakephp": "3.3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "*",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Notifier plugin for CakePHP",
     "type": "cakephp-plugin",
     "require": {
-        "php": ">=5.4.16"
+        "php": ">=5.4.16",
     },
     "require-dev": {
         "phpunit/phpunit": "*",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bakkerij/notifier",
+    "name": "B1scuit/notifier",
     "description": "Notifier plugin for CakePHP",
     "type": "cakephp-plugin",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "B1scuit/notifier",
+    "name": "b1scuit/notifier",
     "description": "Notifier plugin for CakePHP",
     "type": "cakephp-plugin",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,10 @@
 {
-    "name": "b1scuit/notifier",
+    "name": "bakkerij/notifier",
     "description": "Notifier plugin for CakePHP",
     "type": "cakephp-plugin",
     "require": {
         "php": ">=5.4.16",
+        "cakephp/cakephp": "3.3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "*",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Notifier plugin for CakePHP",
     "type": "cakephp-plugin",
     "require": {
-        "php": ">=5.4.16",
+        "php": ">=5.4.16"
     },
     "require-dev": {
         "phpunit/phpunit": "*",


### PR DESCRIPTION
CakePHP version updated to 3.3.X, strongly advise running composer
update before installing however this allows CakePHP to meet install requirements on new installs of the notifier 
