### PR TITLE
Adds templates config file for managing templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,41 @@ After loading the plugin you need to migrate the tables for the plugin using:
 
 #### Templates
 
-Before sending any notification, we need to register a template. An example about how to add templates:
+Before sending any notification, we need to register a template. There are two ways to add templates:
+
+##### 1. Using NotificationManager utility class to create templates
 
 ```php
+    use Bakkerij\Notifier\Utility\NotificationManager;
+
+    $notificationManager = NotificationManager::instance();
     $notificationManager->addTemplate('newBlog', [
         'title' => 'New blog by :username',
         'body' => ':username has posted a new blog named :name'
     ]);
 ```
+
+##### 2. Using config files to define templates
+
+Create a file in your config folder named `templates.php` and create your templates as below:
+
+```php
+    return [
+        'Notifier' => [
+            'templates' => [
+                'newBlog' => [
+                    'title' => 'New blog by :username',
+                    'body' => ':username has posted a new blog named :name'
+                ],
+                'newMessage' => [
+                    'title' => 'New message from :username',
+                    'body' => ':username sent you a message on :timeago'
+                ]
+            ]
+        ]
+    ];
+```
+
 
 When adding a new template, you have to add a `title` and a `body`. Both are able to contain variables like `:username`
 and `:name`. Later on we will tell more about these variables.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Create a file in your config folder named `templates.php` and create your templa
     ];
 ```
 
+Then load your file from your bootstrap.php file:
+
+```php
+    Configure::write('Notifier.config', ['templates']);
+```
+
 
 When adding a new template, you have to add a `title` and a `body`. Both are able to contain variables like `:username`
 and `:name`. Later on we will tell more about these variables.

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -22,7 +22,6 @@ Configure::write('Notifier.templates.default', [
 
 Configure::write('Notifier.recipientLists', []);
 
-
 collection((array)Configure::read('Notifier.config'))->each(function ($file) {
     Configure::load($file);
 });

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -21,3 +21,8 @@ Configure::write('Notifier.templates.default', [
 ]);
 
 Configure::write('Notifier.recipientLists', []);
+
+
+collection((array)Configure::read('Notifier.config'))->each(function ($file) {
+    Configure::load($file);
+});

--- a/src/Model/Entity/Notification.php
+++ b/src/Model/Entity/Notification.php
@@ -94,6 +94,7 @@ class Notification extends Entity
 
             return Text::insert($template['title'], $vars);
         }
+
         return '';
     }
 
@@ -117,6 +118,7 @@ class Notification extends Entity
 
             return Text::insert($template['body'], $vars);
         }
+
         return '';
     }
 
@@ -132,6 +134,7 @@ class Notification extends Entity
         if ($this->_properties['state'] === 1) {
             return true;
         }
+
         return false;
     }
 
@@ -147,6 +150,7 @@ class Notification extends Entity
         if ($this->_properties['state'] === 0) {
             return true;
         }
+
         return false;
     }
 

--- a/src/Utility/NotificationManager.php
+++ b/src/Utility/NotificationManager.php
@@ -43,6 +43,7 @@ class NotificationManager
         if (empty(static::$_generalManager)) {
             static::$_generalManager = new NotificationManager();
         }
+
         return static::$_generalManager;
     }
 
@@ -203,6 +204,7 @@ class NotificationManager
             if ($type == 'body') {
                 return $templates[$name]['body'];
             }
+
             return $templates[$name];
         }
 
@@ -224,6 +226,7 @@ class NotificationManager
         for ($i = 0; $i < 10; $i++) {
             $trackingId .= $characters[rand(0, $charactersLength - 1)];
         }
+
         return $trackingId;
     }
 }

--- a/tests/TestCase/Model/Table/NotificationsTableTest.php
+++ b/tests/TestCase/Model/Table/NotificationsTableTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
  */
 class NotificationsTableTest extends TestCase
 {
-    
+
     public $fixtures = [
         'plugin.bakkerij\Notifier.notifications',
     ];


### PR DESCRIPTION
With this improvement;
- You can use the plugin as it was without changing anything. 
- You can create templates in a config file so you don't need to create an instance of utility class if you don't need it. 
- Check new ways for templating on readme. 
